### PR TITLE
get lower/upper bounds of a given week nbr

### DIFF
--- a/iso_week.go
+++ b/iso_week.go
@@ -25,6 +25,38 @@ func New(t time.Time) *ISOWeek {
 	}
 }
 
+// FromWeekNbr is useful to retrieve lower and uppper bounds of a week number (using UTC time).
+func FromWeekNbr(yr, wk int) *ISOWeek {
+	lower := time.Date(yr, 0, 0, 0, 0, 0, 0, time.UTC)
+	isoYear, isoWeek := lower.ISOWeek()
+
+	//  back to Monday
+	for lower.Weekday() != time.Monday {
+		lower = lower.AddDate(0, 0, -1)
+		isoYear, isoWeek = lower.ISOWeek()
+	}
+
+	// forward to the first day of the first week
+	for isoYear < yr {
+		lower = lower.AddDate(0, 0, 7)
+		isoYear, isoWeek = lower.ISOWeek()
+	}
+
+	// forward to the first day of the given week
+	for isoWeek < wk {
+		lower = lower.AddDate(0, 0, 7)
+		isoYear, isoWeek = lower.ISOWeek()
+	}
+	upper := lower.AddDate(0, 0, 7)
+	upper = upper.Add(-1)
+	return &ISOWeek{
+		Year:       yr,
+		Week:       wk,
+		LowerBound: lower,
+		UpperBound: upper,
+	}
+}
+
 // Equals checks whether or not two iso weeks have the same value (year + week).
 func (iw *ISOWeek) Equals(other *ISOWeek) bool {
 	if iw == nil || other == nil {

--- a/iso_week_test.go
+++ b/iso_week_test.go
@@ -4,9 +4,15 @@ import (
 	"testing"
 	"time"
 
-	"bitbucket.org/splice/api/models"
+	"bitbucket.org/splice/api/splice/logger"
 
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	nullTime = "0000-00-00 00:00:00"
+	// Time layout used to process DB time values.
+	DbtimeLayout = "2006-01-02 15:04:05"
 )
 
 func TestNew(t *testing.T) {
@@ -18,8 +24,37 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestFromWeekNbr(t *testing.T) {
+	testCases := []struct {
+		yr    int
+		wk    int
+		lower time.Time
+		upper time.Time
+	}{
+		{2015, 01,
+			time.Date(2014, 12, 29, 0, 0, 0, 0, time.UTC),
+			time.Date(2015, 1, 4, 23, 59, 59, 999999999, time.UTC),
+		},
+		{2015, 9,
+			time.Date(2015, 2, 23, 0, 0, 0, 0, time.UTC),
+			time.Date(2015, 3, 1, 23, 59, 59, 999999999, time.UTC),
+		},
+		{2015, 53,
+			time.Date(2015, 12, 28, 0, 0, 0, 0, time.UTC),
+			time.Date(2016, 1, 3, 23, 59, 59, 999999999, time.UTC),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Logf("test case %d\n", i)
+		wk := FromWeekNbr(tc.yr, tc.wk)
+		assert.Equal(t, tc.lower, wk.LowerBound, "lower bound of year: %d week: %d - %+v", tc.yr, tc.wk, wk)
+		assert.Equal(t, tc.upper, wk.UpperBound, "upper bound of year: %d week: %d - %+v", tc.yr, tc.wk, wk)
+	}
+}
+
 func TestISOWeekEquals(t *testing.T) {
-	var dbt *models.DbTime
+	var dbt *DbTime
 	iw0 := New(dbt.ToTime())
 	iw1 := New(time.Date(2014, 1, 4, 0, 0, 0, 0, time.UTC))
 	iw2 := New(time.Date(2014, 12, 31, 0, 0, 0, 0, time.UTC))
@@ -33,4 +68,35 @@ func TestISOWeekEquals(t *testing.T) {
 	assert.False(t, iw1.Equals(iw2)) // year mismatch
 	assert.True(t, iw2.Equals(iw3))
 	assert.False(t, iw3.Equals(iw4)) // week mismatch
+}
+
+type DbTime struct {
+	String string
+	Time   time.Time
+}
+
+func (t *DbTime) ToTime() time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	if !t.Time.IsZero() {
+		return t.Time
+	}
+	if t.String != "" && t.String != nullTime {
+		ts, err := time.Parse(DbtimeLayout, t.String)
+		if err != nil {
+			logger.Error(err)
+			return time.Time{}
+		}
+		t.Time = ts
+		return t.Time
+	}
+	return time.Time{}
+}
+
+func (t *DbTime) ToString() string {
+	if t.String == "" && !t.Time.IsZero() {
+		t.String = t.Time.Format(DbtimeLayout)
+	}
+	return t.String
 }


### PR DESCRIPTION
This is a useful addition if you have given a week number and need to find out the lower and upper limits. A concrete use case would be to find all activities that happened during a specific week.

/CC @kytrinyx 
